### PR TITLE
Use new DataFrames syntax in docs

### DIFF
--- a/docs/src/workflow.md
+++ b/docs/src/workflow.md
@@ -165,7 +165,7 @@ using CSV
 using DataFrames
 gr(size=(800,400)) # hide
 
-df = DataFrame!(CSV.File("data/agriculture.csv"))
+df = DataFrame(CSV.File("data/agriculture.csv"))
 
 first(df, 5)
 ```
@@ -179,7 +179,7 @@ Because the labels are categorical variables, we need to inform the framework
 the correct type:
 
 ```@example workflow
-categorical!(df, :crop)
+transform!(df, :crop => categorical => :crop)
 
 first(df, 5)
 ```


### PR DESCRIPTION
I spotted these while reading the docs: `DataFrame!` and `categorical!` are going away in the next DataFrames release. The former isn't needed, the latter has a slightly less convenient replacement (it has to go away so that we can drop the dependency on CategoricalArrays after 1.0 if we want).