### PR TITLE
Mention GeoStatsPlots/Viz in plotting docs

### DIFF
--- a/docs/src/plotting.md
+++ b/docs/src/plotting.md
@@ -1,7 +1,11 @@
 # Plotting
 
-Most objects defined in GeoStats.jl can be plotted directly using the
-`plot` command from [Plots.jl](https://github.com/JuliaPlots/Plots.jl).
+Most objects defined in GeoStats.jl can be plotted directly with
+[Plots.jl](https://github.com/JuliaPlots/Plots.jl) or 
+[Makie.jl](https://github.com/MakieOrg/Makie.jl). In order to do this, 
+first install [GeoStatsPlots.jl](https://github.com/JuliaEarth/GeoStatsPlots.jl)
+(for Plots.jl) or [GeoStatsViz.jl](https://github.com/JuliaEarth/GeoStatsViz.jl) 
+(for Makie.jl), which define recipes for each plotting library.
 For visualization of 3D objects, however, we recommend the experimental
 [MeshViz.jl](https://github.com/JuliaGeometry/MeshViz.jl) package.
 Additional plots are listed below that can be useful for geostatistical


### PR DESCRIPTION
I missed the release announcement that mentioned the plotting recipes being split out, and got confused when they stopped working. The new GeoStats plotting packages are mentioned elsewhere in the docs, but not explicitly here.