### PR TITLE
fix typo

### DIFF
--- a/docs/src/assets/dark.scss
+++ b/docs/src/assets/dark.scss
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-// The customizable varibles can be found here:
+// The customizable variables can be found here:
 // https://github.com/JuliaDocs/Documenter.jl/tree/master/assets/html/scss
 // under documenter/_variables or documenter/_overrides. But some stuff are Bulma defaults
 // as well, so you may need to look them up too: https://bulma.io/documentation/customize/variables/

--- a/docs/src/assets/light.scss
+++ b/docs/src/assets/light.scss
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-// The customizable varibles can be found here:
+// The customizable variables can be found here:
 // https://github.com/JuliaDocs/Documenter.jl/tree/master/assets/html/scss
 // under documenter/_variables or documenter/_overrides. But some stuff are Bulma defaults
 // as well, so you may need to look them up too: https://bulma.io/documentation/customize/variables/


### PR DESCRIPTION
Regrettably, I overlooked in GeoStats `#272` the typo `varibles` in docs/src/assets/*.scss.