### PR TITLE
Fix viewer: constant columns with missing values

### DIFF
--- a/ext/viewer.jl
+++ b/ext/viewer.jl
@@ -26,12 +26,13 @@ function viewer(data::AbstractGeoTable; kwargs...)
   end
 
   # constant variables
-  isconst = Dict(var => allequal(Tables.getcolumn(cols, var)) for var in viewable)
+  isconst = Dict(var => allequal(skipmissing(Tables.getcolumn(cols, var))) for var in viewable)
 
   # list of menu options
   options = map(viewable) do var
     if isconst[var]
-      val = Tables.getcolumn(cols, var) |> first |> asstring
+      vals = skipmissing(Tables.getcolumn(cols, var))
+      val = isempty(vals) ? missing : first(vals)
       "$var = $val (constant)"
     else
       "$var"


### PR DESCRIPTION
MWE:
```
julia> a = [missing, 1.0, 1.0, missing]
4-element Vector{Union{Missing, Float64}}:
  missing
 1.0
 1.0
  missing

julia> b = [missing, 1, missing, 1]
4-element Vector{Union{Missing, Int64}}:
  missing
 1
  missing
 1

julia> gtb = georef((; a, b, c = a * u"m", d = b * u"m"), CartesianGrid(2, 2))
4×5 GeoTable over 2×2 CartesianGrid{2,Float64}
┌────────────┬─────────────┬────────────┬─────────────┬─────────────────────────────────────────┐
│     a      │      b      │     c      │      d      │                geometry                 │
│ Continuous │ Categorical │ Continuous │ Categorical │               Quadrangle                │
│ [NoUnits]  │  [NoUnits]  │    [m]     │     [m]     │                                         │
├────────────┼─────────────┼────────────┼─────────────┼─────────────────────────────────────────┤
│  missing   │   missing   │  missing   │   missing   │ Quadrangle((0.0, 0.0), ..., (0.0, 1.0)) │
│    1.0     │      1      │   1.0 m    │     1 m     │ Quadrangle((1.0, 0.0), ..., (1.0, 1.0)) │
│    1.0     │   missing   │   1.0 m    │   missing   │ Quadrangle((0.0, 1.0), ..., (0.0, 2.0)) │
│  missing   │      1      │  missing   │     1 m     │ Quadrangle((1.0, 1.0), ..., (1.0, 2.0)) │
└────────────┴─────────────┴────────────┴─────────────┴─────────────────────────────────────────┘

julia> viewer(gtb)
ERROR: ArgumentError: range step cannot be zero
Stacktrace:
...
```